### PR TITLE
Logic for adding `id` to `list` in createSuccess

### DIFF
--- a/src/vuex-crud/createMutations.js
+++ b/src/vuex-crud/createMutations.js
@@ -93,6 +93,7 @@ const createMutations = ({
         const id = data[idAttribute].toString();
 
         Vue.set(state.entities, id, data);
+        state.list.push(id);
         state.isCreating = false;
         state.createError = null;
         onCreateSuccess(state, response);


### PR DESCRIPTION
Logic for adding `id` to `list` within createSuccess mutation