### PR TITLE
Handle empty responses on create/update gracefully

### DIFF
--- a/src/vuex-crud/createMutations.js
+++ b/src/vuex-crud/createMutations.js
@@ -90,9 +90,10 @@ const createMutations = ({
 
       createSuccess(state, response) {
         const { data } = response;
-        const id = data[idAttribute].toString();
-
-        Vue.set(state.entities, id, data);
+        if (data) {
+          const id = data[idAttribute].toString();
+          Vue.set(state.entities, id, data);
+        }
         state.isCreating = false;
         state.createError = null;
         onCreateSuccess(state, response);
@@ -115,6 +116,7 @@ const createMutations = ({
 
       updateSuccess(state, response) {
         const { data } = response;
+
         const id = data[idAttribute].toString();
 
         Vue.set(state.entities, id, data);
@@ -147,6 +149,7 @@ const createMutations = ({
 
       replaceSuccess(state, response) {
         const { data } = response;
+
         const id = data[idAttribute].toString();
 
         Vue.set(state.entities, id, data);

--- a/test/unit/vuex-crud/createMutations.spec.js
+++ b/test/unit/vuex-crud/createMutations.spec.js
@@ -463,6 +463,31 @@ test('create success', (t) => {
   t.deepEqual(initialState.list, ['1', '5', '6']);
 });
 
+test('create success without providing a data object', (t) => {
+  const onCreateSuccess = sinon.spy();
+
+  const { createSuccess } = createMutations({
+    only: ['CREATE'],
+    onCreateSuccess,
+    idAttribute: 'id'
+  });
+
+  const initialState = {
+    list: ['1', '5', '6'],
+    entities: {}
+  };
+
+  const data = null;
+
+  createSuccess(initialState, { data });
+
+  t.is(initialState.isCreating, false);
+
+  t.is(initialState.createError, null);
+
+  t.deepEqual(initialState.list, ['1', '5', '6']);
+});
+
 test('create success calls onCreateSuccess', (t) => {
   const onCreateSuccess = sinon.spy();
 
@@ -478,6 +503,27 @@ test('create success calls onCreateSuccess', (t) => {
   };
 
   const data = { id: 1 };
+
+  createSuccess(initialState, { data });
+
+  t.true(onCreateSuccess.calledWith(initialState, { data }));
+});
+
+test('create success calls onCreateSuccess without providing a data object', (t) => {
+  const onCreateSuccess = sinon.spy();
+
+  const { createSuccess } = createMutations({
+    only: ['CREATE'],
+    onCreateSuccess,
+    idAttribute: 'id'
+  });
+
+  const initialState = {
+    list: [],
+    entities: {}
+  };
+
+  const data = null;
 
   createSuccess(initialState, { data });
 


### PR DESCRIPTION
createSuccess was assuming that the response.data object would always provide an id.
Actually, when the response was empty, it was throwing an error and returning a Promise.reject().

Now it extracts the response's data only when it isn't empty.
So "no-body" responses aren't rejecting the Promise anymore.

Handle empty responses on create/update gracefully 

Issue#28: https://github.com/JiriChara/vuex-crud/issues/28
